### PR TITLE
Add ssh host CA roles

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -52,6 +52,7 @@
   - { role: ansible-role-dell, tags: [ 'dell' ] }
   - { role: ansible-role-smartd, tags: [ 'smartd', 'smart' ] }
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-serial-console, tags: [ 'serial', 'console' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }

--- a/grid.yml
+++ b/grid.yml
@@ -35,6 +35,7 @@
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }
   - { role: ansible-role-cvmfs, tags: [ 'cvmfs' ] }
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-arc-client, tags: [ 'arc', 'nordugrid' ] }
   - { role: ansible-role-arc-frontend, tags: [ 'arcfrontend' ] }

--- a/install.yml
+++ b/install.yml
@@ -41,6 +41,8 @@
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
+  - { role: ansible-role-ssh-hostca-srv, tags: ['ssh', 'ssh-hostca'] }
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-pdsh-genders, tags: [ 'pdsh', 'genders' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
@@ -62,4 +64,4 @@
   - { role: dns, tags: [ 'dns' ] }
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }
-
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }

--- a/login.yml
+++ b/login.yml
@@ -48,6 +48,7 @@
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-fgci-bash, tags: [ 'bash'] }  
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }
   - { role: ansible-role-dell, tags: [ 'dell' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }

--- a/nfs.yml
+++ b/nfs.yml
@@ -31,6 +31,7 @@
   - { role: ansible-role-dell, tags: [ 'dell' ] }
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
+  - { role: ansible-role-sshd-host-keys-client, tags: [ 'ssh', 'ssh-hostca' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }

--- a/requirements.yml
+++ b/requirements.yml
@@ -206,7 +206,7 @@
 
 - src: https://github.com/jabl/ansible-role-ssh-hostca-srv
   path: roles
-  version: v1.0.0
+  version: v1.0.1
 
 - src: https://github.com/jabl/ansible-role-sshd-host-keys-client
   path: roles

--- a/requirements.yml
+++ b/requirements.yml
@@ -203,3 +203,11 @@
 - src: https://github.com/CSC-IT-Center-for-Science/ansible-role-chrony
   path: roles
   version: v1.1.1
+
+- src: https://github.com/jabl/ansible-role-ssh-hostca-srv
+  path: roles
+  version: v1.0.0
+
+- src: https://github.com/jabl/ansible-role-sshd-host-keys-client
+  path: roles
+  version: v1.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -206,7 +206,7 @@
 
 - src: https://github.com/jabl/ansible-role-ssh-hostca-srv
   path: roles
-  version: v1.0.1
+  version: v1.0.2
 
 - src: https://github.com/jabl/ansible-role-sshd-host-keys-client
   path: roles


### PR DESCRIPTION
ansible-role-ssh-hostca-srv role to install, it configures and runs
a ssh host CA signing service.

ansible-role-sshd-host-keys-client to all other nodes, which contacts
the host CA service and gets a signed certificate.

local.yml left alone for now until sites have updated install node.
