### PR TITLE
Install falco and sysdig on compute nodes

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -64,6 +64,7 @@
   - { role: systemd_rpcbind, tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-lldpd, tags: [ 'lldpd', 'lldp' ] }
   - { role: ansible-role-singularity, tags: [ 'singularity' ] }
+  - { role: ansible-role-falco, tags: [ 'falco' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
 
 # Adding a role here? Make sure to add it to local.yml too for the role to be used with ansible-pull

--- a/requirements.yml
+++ b/requirements.yml
@@ -216,3 +216,8 @@
 - src: https://github.com/CSCfi/ansible-role-singularity
   path: roles
   version: v1.0.1
+
+- src: https://github.com/CSCfi/ansible-falco
+  path: roles
+  version: f88505cef537366d4589c2e2816eb921c6d28190
+  name: ansible-role-falco


### PR DESCRIPTION
This provides some useful tools like:
 - csysdig (a top for containers)
 - falco (a service that audits suspicious activity inside containers)

For now only in compute.yml (so not for ansible-pull).

Use CSCfi/ansible-falco fork. The old sysdig role we looked at in #191
 has disappeared

Have tested that "journalctl -xefu falco" writes things to the journal
when "event_generator -a all" is run from within this container:

singularity run docker://sysdig/falco-event-generator