### PR TITLE
changed to yaml syntax, fixed debian bug

### DIFF
--- a/roles/network_interface/tasks/main.yml
+++ b/roles/network_interface/tasks/main.yml
@@ -17,20 +17,24 @@
     reload: "{{ 'yes' if ansible_connection != 'chroot' else 'no' }}"
 
 - name: Make sure the include line is there in interfaces file
-  lineinfile: >
-     regexp="^source\ \/etc\/network\/interfaces.d\/\*"
-     line="source /etc/network/interfaces.d/*"
-     dest=/etc/network/interfaces
-     state=present
-     insertafter=EOF
+  lineinfile:
+     regexp: "^source"
+     line: "source {{ net_path }}/*"
+     dest: /etc/network/interfaces
+     state: present
+     insertafter: EOF
   when: ansible_os_family == "Debian"
 
 - name: Create the directory for interface cfg files
-  file: path=/etc/network/interfaces.d  state=directory
+  file:
+      path: "{{ net_path }}"
+      state: directory
   when: ansible_os_family == "Debian"
 
 - name: Create the network configuration file for ethernet devices
-  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  template:
+     src: "ethernet_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.device }}"
   with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined
   register: ether_result
@@ -38,7 +42,9 @@
      - restart network
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  template:
+     src: "route_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/route-{{ item.device }}"
   with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   register: route_result
@@ -50,7 +56,9 @@
 #  when: ether_result is defined and item.changed
 
 - name: Create the network configuration file for bond devices
-  template: src=bond_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  template:
+     src: "bond_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.device }}"
   with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined
   register: bond_result
@@ -58,23 +66,25 @@
      - restart bond
 
 - name: Make sure the bonding module is loaded
-  modprobe: name=bonding state=present
+  modprobe:
+     name: bonding
+     state: present
   when: bond_result is changed
 
 - name: Write configuration files for route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  template:
+     src: "route_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/route-{{ item.device }}"
   with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   register: route_result
   notify:
      - restart route
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: "{{ bond_result.results }}"
-#  when: bond_result is defined and item.changed
-
 - name: Create the network configuration file for slave in the bond devices
-  template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
+  template:
+     src: "bond_slave_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.1 }}"
   with_subelements:
    - '{{ network_bond_interfaces }}'
    - bond_slaves
@@ -83,16 +93,10 @@
   notify:
      - restart bond
 
-#- shell: ifdown {{ item.item.1 }}; ifup {{ item.item.1 }}
-#  with_items: "{{ bond_port_result.results }}"
-#  when: bond_port_result is defined and item.changed
-
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: "{{ bond_result.results }}"
-#  when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
-
 - name: Create the network configuration file for vlan devices
-  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  template:
+     src: "ethernet_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.device }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined
   register: vlan_result
@@ -100,19 +104,19 @@
      - restart vlan
 
 - name: Write configuration files for rhel route configuration with vlan
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  template:
+     src: "route_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/route-{{ item.device }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   register: route_result
   notify:
      - restart route
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: "{{ vlan_result.results }}"
-#  when: vlan_result is defined and item.changed
-
 - name: Create the network configuration file for bridge devices
-  template: src=bridge_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  template:
+     src: "bridge_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.device }}"
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined
   register: bridge_result
@@ -120,19 +124,20 @@
      - restart bridge
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  template:
+     src: "route_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/route-{{ item.device }}"
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   register: route_result
   notify:
      - restart route
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: "{{ bridge_result.results }}”
-#  when: bridge_result is defined and item.changed
-
 - name: Create the network configuration file for port on the bridge devices
-  lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}
+  lineinfile:
+      dest: "{{ net_path }}/ifcfg-{{ item.1 }}"
+      regexp: '^BRIDGE='
+      line: "BRIDGE={{ item.0.device }}"
   with_subelements:
     - '{{ network_bridge_interfaces }}'
     - ports
@@ -144,7 +149,9 @@
 # IB
 
 - name: Create the network configuration file for IB devices
-  template: src=infiniband_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
+  template:
+     src: "infiniband_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/ifcfg-{{ item.device }}"
   with_items: "{{ network_ib_interfaces }}"
   when: network_ib_interfaces is defined
   register: ib_result
@@ -152,16 +159,16 @@
      - restart ib
 
 - name: Write configuration files for rhel route configuration with vlan
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  template:
+     src: "route_{{ ansible_os_family }}.j2"
+     dest: "{{ net_path }}/route-{{ item.device }}"
   with_items: "{{ network_ib_interfaces }}"
   when: network_ib_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   register: route_result
   notify:
      - restart route
 
-#- shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
-#  with_items: "{{ ib_result.results }}"
-#  when: ib_result is defined and item.changed
 
 - name: flush the handlers - so that network settings are applied before any other roles.
   meta: flush_handlers
+


### PR DESCRIPTION
Hello!
Back to loan some old ansible roles.

Switched to fully yaml syntax, instead of the old foo=bar baz=bar
The Debian part now actually does what the intent was, using {{ net_path }} instead of hard coding the path.
Removed the commented out old code.

Greetings from Ericsson
