### PR TITLE
Update ansible-sshd to v0.8.3

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -62,7 +62,7 @@
 - src: https://github.com/willshersystems/ansible-sshd
   path: roles
   name: ansible-role-sshd
-  version: v0.7.6
+  version: v0.8.3
 
 - src: https://github.com/CSCfi/ansible-system-limits
   path: roles


### PR DESCRIPTION
Improves compatibility with RHEL/CentOS 8