### PR TITLE
dhclient to run as persistent even if dhcp-server is not currently an…

### DIFF
--- a/roles/network_interface/templates/ethernet_RedHat.j2
+++ b/roles/network_interface/templates/ethernet_RedHat.j2
@@ -22,6 +22,7 @@ VLAN=yes
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
 BOOTPROTO=dhcp
+PERSISTENT_DHCLIENT=y
 {% endif %}
 
 {% if item.ipv6_address is defined %}


### PR DESCRIPTION
IMHO, it would be better if dhcp-clients wouldn't turn of the interface, if they can't reach the dhcp-server, but just hold on to the previous IP.